### PR TITLE
Persist and manage conversation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ A simple Streamlit app that shows how to build a chatbot using OpenAI's GPT-3.5.
    ```
    $ streamlit run streamlit_app.py
    ```
+
+### Conversation history
+
+Chat messages are stored in a local SQLite database (`chat_history.db`). Use the sidebar controls to reset the conversation or export the history as a JSON file.


### PR DESCRIPTION
## Summary
- store chat messages and admin tasks in a local SQLite database
- load saved history on startup, saving new messages as they arrive
- add sidebar controls to reset or export conversation history

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb083e582c83229bb53ea9e0b102fa