### PR TITLE
Allow OpenAI API key from env or secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ A simple Streamlit app that shows how to build a chatbot using OpenAI's GPT-3.5.
    $ streamlit run streamlit_app.py
    ```
 
+3. Provide your OpenAI API key by one of these methods:
+
+   - Set an `OPENAI_API_KEY` environment variable.
+   - Add an `OPENAI_API_KEY` entry to `.streamlit/secrets.toml`.
+   - Enter the key manually when the app prompts for it.
+
 ### Conversation history
 
 Chat messages are stored in a local SQLite database (`chat_history.db`). Use the sidebar controls to reset the conversation or export the history as a JSON file.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,7 @@
 import json
 import sqlite3
 import logging
+import os
 from pathlib import Path
 import streamlit as st
 import openai
@@ -136,10 +137,13 @@ def clear_history():
     st.session_state.admin_tasks = []
 
 
-# Ask user for their OpenAI API key via `st.text_input`.
-# Alternatively, you can store the API key in `./.streamlit/secrets.toml` and access it
-# via `st.secrets`, see https://docs.streamlit.io/develop/concepts/connections/secrets-management
-openai_api_key = st.text_input("OpenAI API Key", type="password")
+# Retrieve OpenAI API key from Streamlit secrets or environment variables.
+openai_api_key = st.secrets.get("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+
+# If no key is found, ask the user for it via `st.text_input`.
+if not openai_api_key:
+    openai_api_key = st.text_input("OpenAI API Key", type="password")
+
 if not openai_api_key:
     st.info("Please add your OpenAI API key to continue.", icon="🗝️")
 else:


### PR DESCRIPTION
## Summary
- use OpenAI API key from Streamlit secrets or environment before prompting
- document ways to supply the key

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb0b94be1c83228312c12358baeed8