### PR TITLE
Add assistant tools and slash-command workflow

### DIFF
--- a/assistant_tools.py
+++ b/assistant_tools.py
@@ -11,13 +11,23 @@ actions an assistant might perform such as scheduling meetings,
 
 from pathlib import Path
 import sqlite3
-from typing import List
 
 DB_PATH = Path("chat_history.db")
 
+# Public functions exposed to the chat interface
+__all__ = ["schedule_meeting", "send_email", "manage_todo"]
+
 
 def schedule_meeting(topic: str, time: str) -> str:
-    """Return a confirmation message for scheduling a meeting."""
+    """Return a confirmation message for scheduling a meeting.
+
+    Parameters
+    ----------
+    topic:
+        Subject of the meeting.
+    time:
+        When the meeting should occur.
+    """
     return f"Scheduled a meeting about '{topic}' at {time}."
 
 


### PR DESCRIPTION
## Summary
- add standalone `assistant_tools` module with meeting scheduling, email sending, and todo management helpers
- allow Streamlit app to execute `/schedule`, `/email`, and `/todo` commands without a model call
- integrate command handling into chat workflow while retaining OpenAI function-calling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb22b5b1cc8322aa4f264faf25d8b2