### PR TITLE
Check for stored API key before prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ A simple Streamlit app that shows how to build a chatbot using OpenAI's GPT-3.5.
 
 3. Provide your OpenAI API key by one of these methods:
 
-   - Set an `OPENAI_API_KEY` environment variable.
    - Add an `OPENAI_API_KEY` entry to `.streamlit/secrets.toml`.
+   - Set an `OPENAI_API_KEY` environment variable.
    - Enter the key manually when the app prompts for it.
+
+   The app checks Streamlit secrets first, then environment variables, and only
+   prompts for manual entry if a key isn't found.
 
 ### Conversation history
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -187,7 +187,9 @@ def handle_explicit_command(prompt: str) -> str | None:
 
 
 # Retrieve OpenAI API key from Streamlit secrets or environment variables.
-openai_api_key = st.secrets.get("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+openai_api_key = st.secrets.get("OPENAI_API_KEY")
+if not openai_api_key:
+    openai_api_key = os.environ.get("OPENAI_API_KEY")
 
 # If no key is found, ask the user for it via `st.text_input`.
 if not openai_api_key:


### PR DESCRIPTION
## Summary
- Load OpenAI API key from Streamlit secrets or environment variables before asking the user
- Document ways to provide the API key

## Testing
- `python -m py_compile streamlit_app.py assistant_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb26b72fa88322bfee29599730dc2c