### PR TITLE
Prepend system message for admin tone

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -247,6 +247,11 @@ else:
                 {"role": m["role"], "content": m["content"]}
                 for m in st.session_state.messages
             ]
+            system_message = {
+                "role": "system",
+                "content": "You are an AI administrative assistant...",
+            }
+            history = [system_message] + history
 
             try:
                 # Ask the model for a response, allowing it to call tools.


### PR DESCRIPTION
## Summary
- Prepend a system message establishing the assistant as an administrative aide before forwarding chat history to OpenAI.
- Ensure message history includes this system message for subsequent tool-assisted completions.

## Testing
- `python -m py_compile streamlit_app.py`
- Unable to verify chat response; no OpenAI API key provided.


------
https://chatgpt.com/codex/tasks/task_e_68bb2762910c8322b25e4d09149f3a66